### PR TITLE
Replace zgen with zgenom in install instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,8 +26,8 @@ If you want similar functionality for [zoxide](https://github.com/ajeetdsouza/zo
 
 ### zsh plugin
 - Install the zsh plugin using your favorite plugin manager, e.g.:
-	- [zgen](https://github.com/tarjoilija/zgen):
-		-	`zgen load fdw/ranger_autojump`
+	- [zgenom](https://github.com/jandamm/zgenom):
+		-	`zgenom load fdw/ranger_autojump`
 	- [antigen](https://github.com/zsh-users/antigen):
 		-	`antigen bundle fdw/ranger_autojump@main`
 	- [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh):


### PR DESCRIPTION
zgen is unmaintained and hasn't been updated in four years. zgenom is an actively maintained fork though, so update install instructions to replace zgen with zgenom.