### PR TITLE
use fzf to navigate through completion proposals

### DIFF
--- a/autojump.py
+++ b/autojump.py
@@ -9,21 +9,68 @@ def hook_init(fm):
     def update_autojump(signal):
         subprocess.Popen(["autojump", "--add", signal.new.path])
 
-    fm.signal_bind('cd', update_autojump)
+    fm.signal_bind("cd", update_autojump)
     HOOK_INIT_OLD(fm)
-
 
 ranger.api.hook_init = hook_init
 
 
 class j(Command):
-    """:j
+    """:j [<text>]
+
     Uses autojump to set the current directory.
+
+    It works in the same way as the `j` function provided by autojump. In
+    addition, if fzf is present on the system, it is used to browse the
+    completion proposals returned by autojump.
     """
 
     def execute(self):
-        directory = subprocess.check_output(["autojump", self.arg(1)])
-        directory = directory.decode("utf-8", "ignore")
-        directory = directory.rstrip('\n')
-        self.fm.execute_console("cd -r " + directory)
+        import os.path
+        import re
+        from ranger.ext.get_executables import get_executables
+
+        if "autojump" not in get_executables():
+            return self.fm.notify("Could not find autojump in the PATH.", bad=True)
+
+        if "fzf" not in get_executables():
+            directory = subprocess.check_output(["autojump", self.arg(1)])
+            directory = directory.decode("utf-8", "ignore")
+            directory = directory.rstrip("\n")
+            self.fm.cd(directory)
+        else:
+            autojump = self.fm.execute_command(
+                " ".join(["autojump --complete", self.arg(1)]),
+                universal_newlines=True,
+                stdout=subprocess.PIPE,
+            )
+            autojump_stdout, autojump_stderr = autojump.communicate()
+
+            if autojump.returncode == 0:
+                if autojump_stdout.rstrip("\n"):
+                    fzf = self.fm.execute_command(
+                        " ".join(
+                            [
+                                "autojump --complete",
+                                self.arg(1),
+                                "| fzf --no-multi --layout=reverse --ansi 2>/dev/tty",
+                            ]
+                        ),
+                        universal_newlines=True,
+                        stdout=subprocess.PIPE,
+                    )
+                    fzf_stdout, fzf_stderr = fzf.communicate()
+
+                    if fzf.returncode == 0:
+                        fzf_file = fzf_stdout.rstrip("\n")
+                        fzf_file_path = re.sub(self.arg(1) + "__[1-9]__", "", fzf_file)
+                        # print(fzf_file_path)
+                        if os.path.isdir(fzf_file_path):
+                            self.fm.cd(fzf_file_path)
+                        else:
+                            self.fm.select_file(fzf_file_path)
+                else:  # sdtout is empty
+                    return self.fm.notify(
+                        "autojump: no match found for `%s`" % self.arg(1), bad=True
+                    )
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 This plugin for ranger adds complete support for [autojump](https://github.com/wting/autojump) to [ranger](https://github.com/ranger/ranger):
 Whenever a new directory is opened in ranger, autojump is notified and can change the weights accordingly.
-Using `:j` you can use autojump to jump to a directory. This is made even better by adding `map cj console j%space` to your `rc.conf`. Thus typing `cj dirname` will let you jump to dirname.
+Using `:j` you can use autojump to jump to a directory and if [fzf](https://github.com/junegunn/fzf) is found in the PATH, you will be able to browse through the directory proposals. This is made even better by adding `map cj console j%space` to your `rc.conf`. Thus typing `cj dirname` will let you jump to dirname.
 
 As an added bonus, there is a zsh plugin introducing a new function called `r`. Without arguments, it just opens ranger. If you supply an argument that is a directory, ranger is opened in that directory. But if you supply anything else as an argument, `autojump` is called with the argument and `ranger` is opened there 🧙
 


### PR DESCRIPTION
Hello,

I've extended the script to allow navigation through the possible completions proposed by `autojump` in case `fzf` is present in the PATH.
